### PR TITLE
Initial: jupyter/r-notebook with Java 8, RJDBC, and Athena driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: generic
+
+sudo: required
+services:
+    - docker
+
+script:
+    - make build
+    - make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM jupyter/r-notebook
+
+MAINTAINER James Ramsay <git@jwr.vc>
+
+USER root
+
+# Temporarily add jessie backports to get openjdk 8, but then remove that source
+# Java 8 is a dependency of the Athena JDBC driver
+RUN echo 'deb http://cdn-fastly.deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list && \
+    apt-get -y update && \
+    apt-get install --no-install-recommends -t jessie-backports -y openjdk-8-jdk openjdk-8-jre-headless ca-certificates-java && \
+    rm /etc/apt/sources.list.d/jessie-backports.list && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* &&\
+    /usr/sbin/update-java-alternatives -s java-1.8.0-openjdk-amd64
+
+USER $NB_USER
+
+RUN conda install --quiet --yes 'r-rjava'
+
+# By default R fails to find jni.h so we specify the include directory manually
+RUN R CMD javareconf JAVA_CPPFLAGS=-I/usr/lib/jvm/default-java/include
+
+# Installing RJDBC fails unless we set the LD_LIBRARY_PATH to point to paths containing libjvm.so
+ENV LD_LIBRARY_PATH=/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64
+
+COPY rjdbc.R /tmp
+RUN R -f /tmp/rjdbc.R
+
+COPY athena.R /tmp
+RUN R -f /tmp/athena.R
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+OWNER:=jamesramsay
+
+NAME:=jupyter-rjdbc
+
+# Use bash for inline if-statements in test target
+SHELL:=bash
+
+build: ## build the latest image
+	docker build --rm --force-rm -t $(OWNER)/$(NAME):latest .
+
+test: ## check for jupyter server liveliness
+	@-docker rm -f iut
+	@docker run -d --name iut $(OWNER)/$(NAME)
+	@for i in $$(seq 0 9); do \
+		sleep $$i; \
+		docker exec iut bash -c 'wget http://localhost:8888 -O- | grep -i jupyter'; \
+		if [[ $$? == 0 ]]; then exit 0; fi; \
+	done ; exit 1
+

--- a/athena.R
+++ b/athena.R
@@ -1,0 +1,6 @@
+URL <- 'https://s3.amazonaws.com/athena-downloads/drivers/AthenaJDBC41-1.0.1.jar'
+fil <- basename(URL)
+
+if (!file.exists(fil)) download.file(URL, fil)
+
+fil

--- a/rjdbc.R
+++ b/rjdbc.R
@@ -1,0 +1,2 @@
+install.packages("RJDBC", repos="https://rforge.net/")
+


### PR DESCRIPTION
The Athena JDBC driver requires Java 8, but the official [jupyter/r-notebook](https://hub.docker.com/r/jupyter/r-notebook/) only runs Java 7.